### PR TITLE
feat(double quotes): Adds the parameter double_quotes=false/true

### DIFF
--- a/strictjson/base.py
+++ b/strictjson/base.py
@@ -420,7 +420,7 @@ def get_fn_description(my_function) -> (str, list):
 
 ### Main Functions ###
                 
-def strict_json(system_prompt: str, user_prompt: str, output_format: dict, custom_checks: dict = dict(), check_data = None, delimiter: str = '###', num_tries: int = 3, openai_json_mode: bool = False, **kwargs):
+def strict_json(system_prompt: str, user_prompt: str, output_format: dict, double_quotes=False, custom_checks: dict = dict(), check_data = None, delimiter: str = '###', num_tries: int = 3, openai_json_mode: bool = False, **kwargs):
     ''' Ensures that OpenAI will always adhere to the desired output JSON format defined in output_format. 
     Uses rule-based iterative feedback to ask GPT to self-correct.
     Keeps trying up to num_tries it it does not. Returns empty JSON if unable to after num_tries iterations.
@@ -507,7 +507,10 @@ Update text enclosed in <>. Be concise. Output only the json string without any 
                                 raise Exception(f'Output field of "{key}" does not meet requirement "{requirement}". Action needed: "{action_needed}"')
                             else:
                                 print('Requirement met\n\n')
-                return end_dict
+                if double_quotes:
+                    return json.loads(json.dumps(end_dict, ensure_ascii=False))
+                else:
+                    return end_dict
 
             except Exception as e:
                 error_msg = f"\n\nPrevious json: {res}\njson error: {str(e)}\nFix the error."                

--- a/strictjson/base.py
+++ b/strictjson/base.py
@@ -508,7 +508,7 @@ Update text enclosed in <>. Be concise. Output only the json string without any 
                             else:
                                 print('Requirement met\n\n')
                 if double_quotes:
-                    return json.loads(json.dumps(end_dict, ensure_ascii=False))
+                    return json.dumps(end_dict, ensure_ascii=False)
                 else:
                     return end_dict
 


### PR DESCRIPTION
You can call the strict_json function with the double_quotes parameter to control the output format:

```python
# Use single quotes (default)
result = strict_json(system_prompt, user_prompt, output_format)

# Use double quotes
result = strict_json(system_prompt, user_prompt, output_format, double_quotes=True)
```