### PR TITLE
import openai when necessary

### DIFF
--- a/strictjson/agent.py
+++ b/strictjson/agent.py
@@ -1,6 +1,4 @@
 import heapq
-import openai
-from openai import OpenAI
 import numpy as np
 import copy
 import dill as pickle
@@ -42,6 +40,7 @@ class Ranker:
      
         # defaults to OpenAI if ranking_fn is not provided
         if self.ranking_fn is None:
+            from openai import OpenAI
             client = OpenAI()
             if query in self.database:
                 query_embedding = self.database[query]

--- a/strictjson/base.py
+++ b/strictjson/base.py
@@ -638,7 +638,7 @@ Update text enclosed in <>. Output only a valid json string beginning with {{ an
             my_user_prompt = str(user_prompt) 
 
             # Use OpenAI to get a response
-            res = chat(my_system_prompt, my_user_prompt, **kwargs)
+            res = await chat_async(my_system_prompt, my_user_prompt, **kwargs)
             
             # extract only the chunk including the opening and closing braces
             startindex = res.find('{')

--- a/strictjson/base.py
+++ b/strictjson/base.py
@@ -1,12 +1,8 @@
-import os
-import openai
 import json
 import re
 import ast
-import copy
 import inspect
 from typing import get_type_hints
-from openai import OpenAI
 
 ### Helper Functions ###
 
@@ -347,7 +343,8 @@ def chat(system_prompt: str, user_prompt: str, model: str = 'gpt-3.5-turbo', tem
                 assert(model in ['gpt-4-1106-preview', 'gpt-3.5-turbo-1106'])
             except Exception as e:
                 model = 'gpt-3.5-turbo-1106'
-                
+
+        from openai import OpenAI
         client = OpenAI()
         response = client.chat.completions.create(
             model=model,
@@ -399,7 +396,8 @@ async def chat_async(system_prompt: str, user_prompt: str, model: str = 'gpt-3.5
                 assert(model in ['gpt-4-1106-preview', 'gpt-3.5-turbo-1106'])
             except Exception as e:
                 model = 'gpt-3.5-turbo-1106'
-                
+
+        from openai import OpenAI
         client = OpenAI()
         response = client.chat.completions.create(
             model=model,


### PR DESCRIPTION
In my use case, I do not use OpenAI at all. Instead, I utilize a local LLM. Additionally, my runtime environment is Pyodide, there are some dependencies required by OpenAI that are lacking in this runtime. Therefore, I believe it is a good option to only import openai when needed.

Furthermore, I made corrections to `strict_json_async` because I do not use OpenAI and therefore do not use `openai_json_mode`. I found that this function was calling `chat` instead of `chat_async` in this scenario, so I fixed this issue.